### PR TITLE
SLING-7134 - Script execution order is not deterministic on Java 9

### DIFF
--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/NamedScriptResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/NamedScriptResourceCollector.java
@@ -84,7 +84,7 @@ public class NamedScriptResourceCollector extends AbstractResourceCollector {
     }
 
     @Override
-    protected void getWeightedResources(final Set<Resource> resources,
+    protected void getWeightedResources(final Set<WeightedResource> resources,
                                         final Resource location) {
         final ResourceResolver resolver = location.getResourceResolver();
         // if extension is set, we first check for an exact script match

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollector.java
@@ -183,7 +183,7 @@ public class ResourceCollector extends AbstractResourceCollector {
     }
 
     @Override
-    protected void getWeightedResources(final Set<Resource> resources,
+    protected void getWeightedResources(final Set<WeightedResource> resources,
             final Resource location) {
 
         final ResourceResolver resolver = location.getResourceResolver();
@@ -283,7 +283,7 @@ public class ResourceCollector extends AbstractResourceCollector {
     private boolean checkScriptName(final String scriptName,
             final String selector, final String parentName,
             final String suffix, final String htmlSuffix,
-            final Set<Resource> resources, final Resource child,
+            final Set<WeightedResource> resources, final Resource child,
             final int selIdx) {
         if (selector != null && matches(scriptName, selector, suffix)) {
             addWeightedResource(resources, child, selIdx + 1,
@@ -333,7 +333,7 @@ public class ResourceCollector extends AbstractResourceCollector {
             && lenScriptName == (lenName + lenSuffix);
     }
 
-    private void addLocationServlet(final Set<Resource> resources,
+    private void addLocationServlet(final Set<WeightedResource> resources,
             final Resource location) {
         final String path = location.getPath()
             + ServletResourceProviderFactory.SERVLET_PATH_EXTENSION;

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResource.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResource.java
@@ -131,7 +131,6 @@ final class WeightedResource extends ResourceWrapper implements
             return 1;
         }
 
-        // extensions are equal, compare ordinal (lower ordinal wins)
-        return (ordinal < o.ordinal) ? -1 : 1;
+        return 0;
     }
 }

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/SlingServletResolverTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/SlingServletResolverTest.java
@@ -30,6 +30,7 @@ import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 
+import javax.script.ScriptEngineManager;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServlet;
 
@@ -133,6 +134,11 @@ public class SlingServletResolverTest {
         final Field resolverField = resolverClass.getDeclaredField("resourceResolverFactory");
         resolverField.setAccessible(true);
         resolverField.set(servletResolver, factory);
+
+        // set script engine manager
+        final Field scriptEngineManagerField = resolverClass.getDeclaredField("scriptEngineManager");
+        scriptEngineManagerField.setAccessible(true);
+        scriptEngineManagerField.set(servletResolver, Mockito.mock(ScriptEngineManager.class));
 
         final Bundle bundle = Mockito.mock(Bundle.class);
         Mockito.when(bundle.getBundleId()).thenReturn(1L);

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.servlets.resolver.internal.helper;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.commons.testing.sling.MockResource;
@@ -69,7 +70,7 @@ public class ScriptSelectionTest extends HelperTestBase {
         // Create mock request and get scripts from ResourceCollector
         final MockSlingHttpServletRequest req = makeRequest(method, selectors, extension);
         final ResourceCollector u = ResourceCollector.create(req, null, new String[] {"html"});
-        final Collection<Resource> s = u.getServlets(req.getResourceResolver());
+        final Collection<Resource> s = u.getServlets(req.getResourceResolver(), Collections.EMPTY_LIST);
 
         if(expectedScript == null) {
             assertFalse("No script must be found", s.iterator().hasNext());

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResourceTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResourceTest.java
@@ -72,15 +72,4 @@ public class WeightedResourceTest extends TestCase {
         assertTrue(lr2.compareTo(lr1) > 0);
     }
  
-    public void testCompareToOrdinal() {
-        WeightedResource lr1 = new WeightedResource(0, null, 0, WeightedResource.WEIGHT_NONE);
-        WeightedResource lr2 = new WeightedResource(1, null, 0, WeightedResource.WEIGHT_NONE);
-        
-        // expect the same objects to compare equal
-        assertEquals(0, lr1.compareTo(lr1));
-        assertEquals(0, lr2.compareTo(lr2));
-        
-        assertTrue(lr1.compareTo(lr2) < 0);
-        assertTrue(lr2.compareTo(lr1) > 0);
-    }
 }


### PR DESCRIPTION
* the SlingServletResolver now uses the ScriptEngineManager to help in
picking the most appropriate script to render a resource, based on the available
scripts extensions and the order of the ScriptEngineFactories from the list returned by
ScriptEngineManager#getEngineFactories
* the AbstractResourceCollector will use the ordered list of the ScriptEngineFactories extensions
for sorting the candidate WeightedResources
* added tests for the new resource collection mechanism