### PR TITLE
SLING-7134 - Script execution order is not deterministic on Java 9

### DIFF
--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
@@ -75,25 +75,19 @@ public abstract class AbstractResourceCollector {
         final SortedSet<WeightedResource> resources = new TreeSet<>(new Comparator<WeightedResource>() {
             @Override
             public int compare(WeightedResource o1, WeightedResource o2) {
-                if (o1.equals(o2)) {
-                    return 0;
-                }
-                int comparisonResult = o1.compareTo(o2);
-                if (comparisonResult == 0) {
-                    String o1Extension = getScriptExtension(o1.getName());
-                    String o2Extension = getScriptExtension(o2.getName());
-                    if (StringUtils.isNotEmpty(o1Extension) && StringUtils.isNotEmpty(o2Extension)) {
-                        int o1ExtensionIndex = scriptExtensions.indexOf(o1Extension);
-                        int o2ExtensionIndex = scriptExtensions.indexOf(o2Extension);
-                        if (o1ExtensionIndex > o2ExtensionIndex) {
-                            return -1;
-                        } else if (o1ExtensionIndex == o2ExtensionIndex) {
-                            return 0;
-                        }
-                        return 1;
+                String o1Extension = getScriptExtension(o1.getName());
+                String o2Extension = getScriptExtension(o2.getName());
+                if (StringUtils.isNotEmpty(o1Extension) && StringUtils.isNotEmpty(o2Extension)) {
+                    int o1ExtensionIndex = scriptExtensions.indexOf(o1Extension);
+                    int o2ExtensionIndex = scriptExtensions.indexOf(o2Extension);
+                    if (o1ExtensionIndex > o2ExtensionIndex) {
+                        return -1;
+                    } else if (o1ExtensionIndex == o2ExtensionIndex) {
+                        return o1.compareTo(o2);
                     }
+                    return 1;
                 }
-                return comparisonResult;
+                return o1.compareTo(o2);
             }
         });
         final Iterator<String> locations = new LocationIterator(resourceType, resourceSuperType,

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResource.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResource.java
@@ -131,6 +131,7 @@ final class WeightedResource extends ResourceWrapper implements
             return 1;
         }
 
-        return 0;
+        // extensions are equal, compare ordinal (lower ordinal wins)
+        return (ordinal < o.ordinal) ? -1 : 1;
     }
 }

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResourceTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/WeightedResourceTest.java
@@ -71,5 +71,17 @@ public class WeightedResourceTest extends TestCase {
         assertTrue(lr1.compareTo(lr2) < 0);
         assertTrue(lr2.compareTo(lr1) > 0);
     }
+
+    public void testCompareToOrdinal() {
+        WeightedResource lr1 = new WeightedResource(0, null, 0, WeightedResource.WEIGHT_NONE);
+        WeightedResource lr2 = new WeightedResource(1, null, 0, WeightedResource.WEIGHT_NONE);
+
+        // expect the same objects to compare equal
+        assertEquals(0, lr1.compareTo(lr1));
+        assertEquals(0, lr2.compareTo(lr2));
+
+        assertTrue(lr1.compareTo(lr2) < 0);
+        assertTrue(lr2.compareTo(lr1) > 0);
+    }
  
 }


### PR DESCRIPTION
* re-added the ordinal comparison in WeightedResource
* changed comparator from `org.apache.sling.servlets.resolver.internal.helper.AbstractResourceCollector#getServlets`
to first check the extensions for sorting (if existing), then the actual sorting order of the `WeightedResources` if the extensions are the same