### PR TITLE
SLING-8936: add pax-based ServletSelectionIT, starting point for better test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-wrap</artifactId>
+            <version>2.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.paxexam</artifactId>
             <version>3.0.0</version>
@@ -296,6 +302,12 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <version>6.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.servlet-helpers</artifactId>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.paxexam</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
 
     <properties>
         <site.jira.version.id>12314292</site.jira.version.id>
+        <!-- To debug the pax process, override this with -D -->
+        <pax.vm.options>-Xmx256M -XX:MaxPermSize=256m</pax.vm.options>
     </properties>
 
     <build>
@@ -132,6 +134,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <argLine>${pax.vm.options}</argLine>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <systemProperties>
                         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- for ServiceUserMapped (SLING-4312) -->
@@ -283,6 +283,13 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlet-helpers</artifactId>
             <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.scripting.core</artifactId>
+            <!-- SLING-8936 - this version number can move to ServletResolverTestSupport once we use a non-SNAPSHOT version -->
+            <version>2.1.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -285,12 +285,5 @@
             <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.scripting.core</artifactId>
-            <!-- SLING-8936 - this version number can move to ServletResolverTestSupport once we use a non-SNAPSHOT version -->
-            <version>2.1.1-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.20.0</version>
+            <version>2.22.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- for ServiceUserMapped (SLING-4312) -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
                         <Provide-Capability>
                             osgi.extender;osgi.extender="org.apache.sling.servlets.resolver";version:Version="1.0"
                         </Provide-Capability>
+                        <Include-Resource>
+                            <!-- for SLING-7351 -->
+                            META-INF/maven/dependencies.properties=-${project.build.outputDirectory}/META-INF/maven/dependencies.properties,{maven-resources}
+                        </Include-Resource>
                     </instructions>
                 </configuration>
             </plugin>
@@ -104,6 +108,39 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <systemProperties>
+                        <property>
+                        <name>bundle.filename</name>
+                        <value>${basedir}/target/${project.build.finalName}.jar</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -132,7 +169,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.21.0</version>
+            <version>2.20.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- for ServiceUserMapped (SLING-4312) -->
@@ -217,6 +254,48 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>16.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-cm</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-forked</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-link-mvn</artifactId>
+            <version>4.13.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.paxexam</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/apache/sling/servlets/resolver/it/DefaultServletIT.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/DefaultServletIT.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlets.resolver.it;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.BundleContext;
+
+/** Using the SlingRequestProcessor for testing requests would be
+ *  better, but this module has a number of specific settings
+ *  in its pom for the sling.engine module that I prefer not touching
+ *  now as I'm just adding these tests.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class DefaultServletIT extends ServletResolverTestSupport {
+    @Inject
+    private BundleContext bundleContext;
+
+    @Test
+    public void testDefaultServlet() {
+        // TODO for now this just tests the pax exam setup
+        assertTrue(bundleContext.getBundles().length > 0);
+    }
+
+}

--- a/src/test/java/org/apache/sling/servlets/resolver/it/DefaultServletIT.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/DefaultServletIT.java
@@ -38,12 +38,6 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-/**
- * Using the SlingRequestProcessor for testing requests would be better, but
- * this module is using an older version of the sling.engine module that does not
- * have that, along with a number of specific settings for that module, so I prefer
- * not touching those now as I'm just adding these tests.
- */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class DefaultServletIT extends ServletResolverTestSupport {

--- a/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
@@ -23,6 +23,8 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
 
 public class ServletResolverTestSupport extends TestSupport {
@@ -34,6 +36,7 @@ public class ServletResolverTestSupport extends TestSupport {
             baseConfiguration(),
             slingQuickstartOakTar(workingDirectory(), httpPort),
             testBundle("bundle.filename"),
+            wrappedBundle(mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.servlet-helpers").versionAsInProject()),
             junitBundles()
         };
     }

--- a/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlets.resolver.it;
+
+import org.apache.sling.testing.paxexam.TestSupport;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
+
+public class ServletResolverTestSupport extends TestSupport {
+    protected final int httpPort = findFreePort();
+
+    @Configuration
+    public Option[] configuration() {
+        return new Option[]{
+            baseConfiguration(),
+            slingQuickstartOakTar(workingDirectory(), httpPort),
+            testBundle("bundle.filename"),
+            junitBundles()
+        };
+    }
+}

--- a/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
@@ -73,7 +73,7 @@ public class ServletResolverTestSupport extends TestSupport {
                 slingQuickstartOakTar(workingDirectory(), httpPort),
                 mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.api").versionAsInProject(),
                 mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.resourceresolver").version("1.6.16"), // compatible with API 2.22.0
-                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.scripting.core").version("2.1.1-SNAPSHOT"), // compatible with API 2.22.0
+                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.scripting.core").versionAsInProject(), // compatible with API 2.22.0
                 mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.converter").version("1.0.12"), // new Sling API dependency
                 testBundle("bundle.filename"),
                 wrappedBundle(mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.servlet-helpers").versionAsInProject()),

--- a/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
@@ -73,7 +73,7 @@ public class ServletResolverTestSupport extends TestSupport {
                 slingQuickstartOakTar(workingDirectory(), httpPort),
                 mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.api").versionAsInProject(),
                 mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.resourceresolver").version("1.6.16"), // compatible with API 2.22.0
-                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.scripting.core").versionAsInProject(), // compatible with API 2.22.0
+                mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.scripting.core").version("2.1.1-SNAPSHOT"), // compatible with API 2.22.0 - TODO replace with release when available
                 mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.converter").version("1.0.12"), // new Sling API dependency
                 testBundle("bundle.filename"),
                 wrappedBundle(mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.servlet-helpers").versionAsInProject()),

--- a/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/ServletResolverTestSupport.java
@@ -25,6 +25,7 @@ import org.ops4j.pax.exam.Option;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.newConfiguration;
 import static org.apache.sling.testing.paxexam.SlingOptions.slingQuickstartOakTar;
 
 public class ServletResolverTestSupport extends TestSupport {
@@ -37,7 +38,10 @@ public class ServletResolverTestSupport extends TestSupport {
             slingQuickstartOakTar(workingDirectory(), httpPort),
             testBundle("bundle.filename"),
             wrappedBundle(mavenBundle().groupId("org.apache.sling").artifactId("org.apache.sling.servlet-helpers").versionAsInProject()),
-            junitBundles()
+            junitBundles(),
+            newConfiguration("org.apache.sling.jcr.base.internal.LoginAdminWhitelist")
+                .put("whitelist.bundles.regexp", "^PAXEXAM.*$")
+                .asOption(),
         };
     }
 }

--- a/src/test/java/org/apache/sling/servlets/resolver/it/TestServlet.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/it/TestServlet.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlets.resolver.it;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.BundleContext;
+
+public class TestServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private final String name;
+    private final Dictionary<String, Object> properties = new Hashtable<>();
+
+    public static final String SERVED_BY_PREFIX = "SERVED_BY_";
+
+    public TestServlet(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().write(SERVED_BY_PREFIX + name);
+    }
+
+    TestServlet with(String key, Object value) {
+        properties.put(key, value);
+        return this;
+    }
+
+    void register(BundleContext context) {
+        context.registerService(Servlet.class.getName(), this, properties);
+    }
+}


### PR DESCRIPTION
Note that this PR reverts o.a.sling.api to 2.20.0 instead of 2.22.0-SNAPSHOT - do we really need this change? I'll discuss in SLING-8962