### PR TITLE
SLING-10507 Refactor tests to replace usage of deprecated apis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
-            <version>1.2.1-SNAPSHOT</version>
+            <version>1.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
+            <version>1.2.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationIteratorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationIteratorTest.java
@@ -20,9 +20,13 @@ package org.apache.sling.servlets.resolver.internal.helper;
 
 import static org.apache.sling.api.servlets.ServletResolverConstants.DEFAULT_RESOURCE_TYPE;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.commons.testing.sling.MockResource;
 
 public class LocationIteratorTest extends HelperTestBase {
 
@@ -43,7 +47,7 @@ public class LocationIteratorTest extends HelperTestBase {
 
     public void testSearchPathEmpty() {
         // expect path gets { "/" }
-        resourceResolver.setSearchPath((String[]) null);
+        resourceResolverOptions.setSearchPaths(null);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -62,8 +66,10 @@ public class LocationIteratorTest extends HelperTestBase {
     }
 
     public void testSearchPath1Element() {
-        String root0 = "/apps";
-        resourceResolver.setSearchPath(root0);
+        String root0 = "/apps/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0
+        });
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -71,20 +77,23 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 1. /apps/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceTypePath, li.next());
+        assertEquals(root0 + resourceTypePath, li.next());
 
         // 2. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 3. finished
         assertFalse(li.hasNext());
     }
 
     public void testSearchPath2Elements() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -92,32 +101,53 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 1. /apps/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceTypePath, li.next());
+        assertEquals(root0 + resourceTypePath, li.next());
 
         // 2. /libs/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceTypePath, li.next());
+        assertEquals(root1 + resourceTypePath, li.next());
 
         // 3. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 4. /libs/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 5. finished
         assertFalse(li.hasNext());
     }
 
+    /**
+     * Replace a resource with a different type
+     * 
+     * @param res the resource to replace
+     * @param newResourceType the new resource type, or null to not change it
+     * @param newResourceSuperType the new resource super type, or null to not change it
+     * @return the new resource
+     */
+    protected void replaceResource(String newResourceType, String newResourceSuperType) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> props = new HashMap<>(resource.adaptTo(Map.class));
+        if (newResourceType != null) {
+            props.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, newResourceType);
+        }
+        if (newResourceSuperType != null) {
+            props.put("sling:resourceSuperType", newResourceSuperType);
+        }
+        Resource r = addOrReplaceResource(resourceResolver, resource.getPath(), props);
+        request.setResource(r);
+    }
+
     public void testSearchPathEmptyAbsoluteType() {
         // expect path gets { "/" }
-        resourceResolver.setSearchPath((String[]) null);
+        resourceResolverOptions.setSearchPaths(null);
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
+        replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -136,13 +166,15 @@ public class LocationIteratorTest extends HelperTestBase {
     }
 
     public void testSearchPath1ElementAbsoluteType() {
-        String root0 = "/apps";
-        resourceResolver.setSearchPath(root0);
+        String root0 = "/apps/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0
+        });
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
+        replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -154,21 +186,24 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 2. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 3. finished
         assertFalse(li.hasNext());
     }
 
     public void testSearchPath2ElementsAbsoluteType() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
+        replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -180,11 +215,11 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 2. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 3. /libs/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 4. finished
         assertFalse(li.hasNext());
@@ -192,12 +227,12 @@ public class LocationIteratorTest extends HelperTestBase {
 
     public void testSearchPathEmptyWithSuper() {
         // expect path gets { "/" }
-        resourceResolver.setSearchPath((String[]) null);
+        resourceResolverOptions.setSearchPaths(null);
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -220,13 +255,15 @@ public class LocationIteratorTest extends HelperTestBase {
     }
 
     public void testSearchPath1ElementWithSuper() {
-        String root0 = "/apps";
-        resourceResolver.setSearchPath(root0);
+        String root0 = "/apps/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0
+        });
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -234,29 +271,32 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 1. /apps/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceTypePath, li.next());
+        assertEquals(root0 + resourceTypePath, li.next());
 
         // 2. /apps/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root0 + resourceSuperTypePath, li.next());
 
         // 3. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 4. finished
         assertFalse(li.hasNext());
     }
 
     public void testSearchPath2ElementsWithSuper() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -264,27 +304,27 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 1. /apps/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceTypePath, li.next());
+        assertEquals(root0 + resourceTypePath, li.next());
 
         // 2. /libs/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceTypePath, li.next());
+        assertEquals(root1 + resourceTypePath, li.next());
 
         // 3. /apps/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root0 + resourceSuperTypePath, li.next());
 
         // 4. /libs/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root1 + resourceSuperTypePath, li.next());
 
         // 5. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 6. /libs/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 7. finished
         assertFalse(li.hasNext());
@@ -292,17 +332,16 @@ public class LocationIteratorTest extends HelperTestBase {
 
     public void testSearchPathEmptyAbsoluteTypeWithSuper() {
         // expect path gets { "/" }
-        resourceResolver.setSearchPath((String[]) null);
+        resourceResolverOptions.setSearchPaths(null);
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -325,18 +364,19 @@ public class LocationIteratorTest extends HelperTestBase {
     }
 
     public void testSearchPath1ElementAbsoluteTypeWithSuper() {
-        String root0 = "/apps";
-        resourceResolver.setSearchPath(root0);
+        String root0 = "/apps/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0
+        });
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -348,30 +388,32 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 2. /apps/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root0 + resourceSuperTypePath, li.next());
 
         // 3. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 4. finished
         assertFalse(li.hasNext());
     }
 
     public void testSearchPath2ElementsAbsoluteTypeWithSuper() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
 
         // absolute resource type
         resourceType = "/foo/bar";
         resourceTypePath = ResourceUtil.resourceTypeToPath(resourceType);
-        resource.setResourceType(resourceType);
 
         // set resource super type
         resourceSuperType = "foo:superBar";
         resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
-        resource.setResourceSuperType(resourceSuperType);
+        replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
         LocationIterator li = getLocationIterator(r.getResourceType(),
@@ -383,28 +425,31 @@ public class LocationIteratorTest extends HelperTestBase {
 
         // 2. /apps/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root0 + resourceSuperTypePath, li.next());
 
         // 3. /libs/foo/superBar
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceSuperTypePath, li.next());
+        assertEquals(root1 + resourceSuperTypePath, li.next());
 
         // 4. /apps/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 5. /libs/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 6. finished
         assertFalse(li.hasNext());
     }
 
     public void testScriptNameWithoutResourceType() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
         LocationIterator li = getLocationIterator("",
                 null,
                 "");
@@ -416,79 +461,102 @@ public class LocationIteratorTest extends HelperTestBase {
     }
 
     public void testScriptNameWithResourceType() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
         LocationIterator li = getLocationIterator("a/b",
                 null);
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/a/b", li.next());
+        assertEquals(root0 + "a/b", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/a/b", li.next());
+        assertEquals(root1 + "a/b", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
         assertFalse(li.hasNext());
     }
 
     public void testScriptNameWithResourceTypeAndSuperType() {
-        String root0 = "/apps";
-        String root1 = "/libs";
-        resourceResolver.setSearchPath(root0, root1);
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
         LocationIterator li = getLocationIterator("a/b",
                 "c/d");
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/a/b", li.next());
+        assertEquals(root0 + "a/b", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/a/b", li.next());
+        assertEquals(root1 + "a/b", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/c/d", li.next());
+        assertEquals(root0 + "c/d", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/c/d", li.next());
+        assertEquals(root1 + "c/d", li.next());
         assertTrue(li.hasNext());
-        assertEquals(root0 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root0 + DEFAULT_RESOURCE_TYPE, li.next());
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
         assertFalse(li.hasNext());
     }
 
     public void testCircularResourceTypeHierarchy() {
-        final String root1 = "/libs";
-        resourceResolver.setSearchPath(root1);
+        final String root1 = "/libs/";
+        resourceResolverOptions.setSearchPaths(new String[] {
+                root1
+        });
 
         // resource type and super type for start resource
         final String resourceType = "foo/bar";
         final String resourceSuperType = "foo/check1";
         final String resourceSuperType2 = "foo/check2";
 
-        final Resource resource2 = new MockResource(resourceResolver,
-                root1 + '/' + resourceSuperType,
-                resourceType, resourceSuperType2);
-        resourceResolver.addResource(resource2);
-        final Resource resource3 = new MockResource(resourceResolver,
-                root1 + '/' + resourceSuperType2,
-                resourceType, resourceType);
-        resourceResolver.addResource(resource3);
+        String resource2Path = root1 + resourceSuperType;
+        Map<String, Object> resource2Props = new HashMap<>();
+        resource2Props.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, resourceType);
+        resource2Props.put("sling:resourceSuperType", resourceSuperType2);
+        try {
+            resourceResolver.create(getOrCreateParentResource(resourceResolver, resource2Path),
+                    ResourceUtil.getName(resource2Path),
+                    resource2Props);
+        } catch (PersistenceException e) {
+            fail("Did not expect a persistence exception: " + e.getMessage());
+        }
+
+        String resource3Path = root1 + resourceSuperType2;
+        Map<String, Object> resource3Props = new HashMap<>();
+        resource3Props.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, resourceType);
+        resource3Props.put("sling:resourceSuperType", resourceType);
+        try {
+            resourceResolver.create(getOrCreateParentResource(resourceResolver, resource3Path),
+                    ResourceUtil.getName(resource3Path),
+                    resource3Props);
+        } catch (PersistenceException e) {
+            fail("Did not expect a persistence exception: " + e.getMessage());
+        }
 
         LocationIterator li = getLocationIterator(resourceType,
                 resourceSuperType);
 
         // 1. /libs/foo/bar
         assertTrue(li.hasNext());
-        assertEquals(root1 + '/' + resourceType, li.next());
+        assertEquals(root1 + resourceType, li.next());
 
         // 1. /libs/foo/check1
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceSuperType, li.next());
+        assertEquals(root1 + resourceSuperType, li.next());
 
         // 3. /libs/foo/check2
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + resourceSuperType2, li.next());
+        assertEquals(root1 + resourceSuperType2, li.next());
 
         // 4. /libs/sling/servlet/default
         assertTrue(li.hasNext());
-        assertEquals(root1 + "/" + DEFAULT_RESOURCE_TYPE, li.next());
+        assertEquals(root1 + DEFAULT_RESOURCE_TYPE, li.next());
 
         // 5. finished
         assertFalse(li.hasNext());

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollectorTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.commons.testing.sling.MockResource;
 
 public class ResourceCollectorTest extends HelperTestBase {
 
@@ -49,9 +48,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print.esp", // 4
                 "/print/a4.esp", // 5
                 "/print.html.esp", // 6
-                "/print/a4.html.esp", // 7
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.esp" // 7
         };
 
         int[] baseIdxs = { 0, 1, 1, 0, 0, 1, 0, 1, 0, 1 };
@@ -68,9 +65,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print.other.esp", // 4
                 "/print/other.esp", // 5
                 "/print.html.esp", // 6
-                "/print/a4.html.esp", // 7
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.esp" // 7
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -88,9 +83,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.esp", // 5
                 "/print.other.esp", // 6
                 "/print.html.esp", // 7
-                "/print/a4.html.esp", // 8
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.esp" // 8
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -109,9 +102,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.esp", // 6
                 "/print.other.esp", // 7
                 "/print.html.esp", // 8
-                "/print/a4.html.esp", // 9
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.esp" // 9
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -131,9 +122,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.esp", // 7
                 "/print.other.esp", // 8
                 "/print.html.esp", // 9
-                "/print/a4.html.esp", // 10
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.esp" // 10
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1 };
@@ -168,9 +157,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/a4.html.esp", // 10    /libs/foo/bar/print/a4.html.esp
                 "/print/a4.html.js", // 11     /libs/foo/bar/print/a4.html.js
                 "/print/a4.html.html", // 12   /apps/foo/bar/print/a4.html.html
-                "/print/a4.html.jsp", // 13    /apps/foo/bar/print/a4.html.jsp
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.jsp" // 13    /apps/foo/bar/print/a4.html.jsp
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 , 0 , 1, 0};
@@ -201,9 +188,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/a4.html.esp", // 10    /libs/foo/bar/print/a4.html.esp
                 "/print/a4.html.js", // 11     /libs/foo/bar/print/a4.html.js
                 "/print/a4.html.html", // 12   /apps/foo/bar/print/a4.html.html will win (overlays libs, comes before jsp when iterating)
-                "/print/a4.html.jsp", // 13    /apps/foo/bar/print/a4.html.jsp
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.jsp" // 13    /apps/foo/bar/print/a4.html.jsp
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 , 0 , 1, 0};
@@ -232,9 +217,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/a4.html.esp", // 10    /libs/foo/bar/print/a4.html.esp
                 "/print/a4.html.js", // 11     /libs/foo/bar/print/a4.html.js
                 "/print/a4.html.jsp", // 12    /apps/foo/bar/print/a4.html.jsp will win (overlays libs, comes before html when iterating)
-                "/print/a4.html.html", // 13   /apps/foo/bar/print/a4.html.html
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.html" // 13   /apps/foo/bar/print/a4.html.html
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 , 0 , 1, 0};
@@ -259,9 +242,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print.ANY.esp", // 4
                 "/print/a4.ANY.esp", // 5
                 "/print.html.ANY.esp", // 6
-                "/print/a4.html.ANY.esp", // 7
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.esp" // 7
         };
 
         int[] baseIdxs = { 0, 1, 1, 0, 0, 1, 0, 1, 0, 1 };
@@ -281,9 +262,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print.other.ANY.esp", // 4
                 "/print/other.ANY.esp", // 5
                 "/print.html.ANY.esp", // 6
-                "/print/a4.html.ANY.esp", // 7
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.esp" // 7
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -304,9 +283,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.ANY.esp", // 5
                 "/print.other.ANY.esp", // 6
                 "/print.html.ANY.esp", // 7
-                "/print/a4.html.ANY.esp", // 8
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.esp" // 8
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -328,9 +305,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.ANY.esp", // 6
                 "/print.other.ANY.esp", // 7
                 "/print.html.ANY.esp", // 8
-                "/print/a4.html.ANY.esp", // 9
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.esp" // 9
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 };
@@ -353,9 +328,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/other.ANY.esp", // 7
                 "/print.other.ANY.esp", // 8
                 "/print.html.ANY.esp", // 9
-                "/print/a4.html.ANY.esp", // 10
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.esp" // 10
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1 };
@@ -381,9 +354,7 @@ public class ResourceCollectorTest extends HelperTestBase {
                 "/print/a4.html.ANY.esp", // 10    /libs/foo/bar/print/a4.html.ANY.esp
                 "/print/a4.html.ANY.js", // 11     /libs/foo/bar/print/a4.html.ANY.js
                 "/print/a4.html.ANY.html", // 12   /apps/foo/bar/print/a4.html.ANY.html
-                "/print/a4.html.ANY.jsp", // 13    /apps/foo/bar/print/a4.html.ANY.jsp
-                "/print", // resource to enable walking the tree
-                "/print", // resource to enable walking the tree
+                "/print/a4.html.ANY.jsp" // 13    /apps/foo/bar/print/a4.html.ANY.jsp
         };
 
         int[] baseIdxs = { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0 , 0 , 1, 0};
@@ -441,9 +412,7 @@ public class ResourceCollectorTest extends HelperTestBase {
         assertFalse(rIter.hasNext());
     }
 
-    protected MockResource createScriptResource(String path, String type) {
-        MockResource res = new MockResource(resourceResolver, path, type);
-        resourceResolver.addResource(res);
-        return res;
+    protected Resource createScriptResource(String path, String type) {
+        return addOrReplaceResource(resourceResolver, path, type);
     }
 }

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.commons.testing.sling.MockResource;
 import org.apache.sling.commons.testing.sling.MockSlingHttpServletRequest;
 
 /** Various tests that explain and demonstrate how scripts are
@@ -63,8 +62,7 @@ public class ScriptSelectionTest extends HelperTestBase {
     {
         // Add given scripts to our mock resource resolver
         for(String script : scripts) {
-            final MockResource r = new MockResource(resourceResolver, script, "nt:file");
-            resourceResolver.addResource(r);
+            addOrReplaceResource(resourceResolver, script, "nt:file");
         }
 
         // Create mock request and get scripts from ResourceCollector

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/resource/MockServletResource.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/resource/MockServletResource.java
@@ -21,11 +21,32 @@ package org.apache.sling.servlets.resolver.internal.resource;
 import javax.servlet.Servlet;
 
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 
 public class MockServletResource extends
         org.apache.sling.servlets.resolver.internal.resource.ServletResource {
+
+    public static final String PROP_SERVLET = ":servlet";
+
+    private final Servlet servlet;
+
     public MockServletResource(ResourceResolver resourceResolver,
             Servlet servlet, String path) {
         super(resourceResolver, servlet, path);
+        this.servlet = servlet;
     }
+
+    @Override
+    public <T> T adaptTo(Class<T> type) {
+        if ( type == ValueMap.class ) {
+            ValueMapDecorator vm = (ValueMapDecorator)super.adaptTo(type);
+            // add the servlet to the ValueMap so we don't lose track of it
+            //  when resource objects are created during traversal
+            vm.put(PROP_SERVLET, servlet);
+            return type.cast(vm);
+        }
+        return super.adaptTo(type);
+    }
+
 }


### PR DESCRIPTION
org.apache.sling.commons.testing.sling.MockResourceResolver is deprecated

Expected:

use the Mock Resource Resolver Implementation from org.apache.sling.testing.resourceresolver-mock instead.