### PR TITLE
workaround RB issue from depends-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,30 @@
                 <groupId>org.apache.servicemix.tooling</groupId>
                 <artifactId>depends-maven-plugin</artifactId>
             </plugin>
+            <plugin><!-- workaround for https://issues.apache.org/jira/browse/SM-5021 -->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>fix-depends-RB</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>${project.build.directory}/classes/META-INF/maven/dependencies.properties</file>
+                    <replacements>
+                        <replacement>
+                            <token># Generated at: .+</token>
+                            <value>#</value>
+                        </replacement>
+                    </replacements>
+                    <regex>true</regex>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
this is the only remaining issue to get a full repreoducible release: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/sling/org.apache.sling.servlets.resolver/README.md