### PR TITLE
SLING-11558 cache already resolved resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+		    <groupId>org.apache.sling</groupId>
+		    <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
+		    <version>1.4.2</version>
+		    <scope>test</scope>
+		</dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
-            <version>1.2.2</version>
+            <version>1.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>2.5.0</version>
+            <version>3.4.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -317,12 +317,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-		    <groupId>org.apache.sling</groupId>
-		    <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
-		    <version>1.4.2</version>
-		    <scope>test</scope>
-		</dependency>
-        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
             <version>1.4.2</version>

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/ResolverConfig.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/ResolverConfig.java
@@ -68,4 +68,12 @@ public @interface ResolverConfig {
             " If false (the default), servlets will be represented in the content tree using individual resource providers -" +
             " otherwise, servlets will be mounted into the content tree using one resource provider per search path entry. This effectively overrides mount providers.")
     boolean servletresolver_mountPathProviders() default false; // NOSONAR
+    
+    
+    @AttributeDefinition(name="use resource caching", description = "Use an optimized version of the servlet resolution which "
+    		+ "uses caching within the ResourceResolver.")
+    boolean enable_resource_caching() default true;
+    
+    
+    
 }

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/SlingServletResolver.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/SlingServletResolver.java
@@ -132,6 +132,9 @@ public class SlingServletResolver
      * The default extensions
      */
     private AtomicReference<String[]> defaultExtensions = new AtomicReference<>();
+    
+    private boolean useResourceCaching;
+    
 
     private final PathBasedServletAcceptor pathBasedServletAcceptor = new PathBasedServletAcceptor();
 
@@ -295,7 +298,7 @@ public class SlingServletResolver
             String extension = request.getRequestPathInfo().getExtension();
             ResourceCollector locationUtil = new ResourceCollector(String.valueOf(status),
                     DEFAULT_ERROR_HANDLER_RESOURCE_TYPE, resource,
-                    extension, this.executionPaths.get());
+                    extension, this.executionPaths.get(), this.useResourceCaching);
             Servlet servlet = getServletInternal(locationUtil, request, scriptResolver);
 
             // fall back to default servlet if none
@@ -353,7 +356,7 @@ public class SlingServletResolver
                 String extension = request.getRequestPathInfo().getExtension();
                 ResourceCollector locationUtil = new ResourceCollector(tClass.getSimpleName(),
                         DEFAULT_ERROR_HANDLER_RESOURCE_TYPE, resource,
-                        extension, this.executionPaths.get());
+                        extension, this.executionPaths.get(), this.useResourceCaching);
                 servlet = getServletInternal(locationUtil, request, scriptResolver);
 
                 // go to the base class
@@ -470,9 +473,9 @@ public class SlingServletResolver
             // the resource type is not absolute, so lets go for the deep search
             final AbstractResourceCollector locationUtil;
             if ( request != null ) {
-                locationUtil = ResourceCollector.create(request, this.executionPaths.get(), this.defaultExtensions.get());
+                locationUtil = ResourceCollector.create(request, this.executionPaths.get(), this.defaultExtensions.get(), this.useResourceCaching);
             } else {
-                locationUtil = NamedScriptResourceCollector.create(scriptNameOrResourceType, resource, this.executionPaths.get());
+                locationUtil = NamedScriptResourceCollector.create(scriptNameOrResourceType, resource, this.executionPaths.get(), this.useResourceCaching);
             }
             servlet = getServletInternal(locationUtil, request, resolver);
 
@@ -598,7 +601,7 @@ public class SlingServletResolver
         final ResourceCollector locationUtil = new ResourceCollector(
             ServletResolverConstants.DEFAULT_ERROR_HANDLER_METHOD,
             DEFAULT_ERROR_HANDLER_RESOURCE_TYPE, resource,
-            extension, this.executionPaths.get());
+            extension, this.executionPaths.get(), this.useResourceCaching);
         final Servlet servlet = getServletInternal(locationUtil, request, resolver);
         if (servlet != null) {
             return servlet;
@@ -677,6 +680,7 @@ public class SlingServletResolver
 
         this.executionPaths.set(getExecutionPaths(config.servletresolver_paths()));
         this.defaultExtensions.set(config.servletresolver_defaultExtensions());
+        this.useResourceCaching = config.enable_resource_caching();
 
         // setup default servlet
         this.getDefaultServlet();

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/console/WebConsolePlugin.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/console/WebConsolePlugin.java
@@ -363,7 +363,7 @@ public class WebConsolePlugin extends HttpServlet {
                     executionPaths.get(),
                     defaultExtensions.get(),
                     method,
-                    requestPathInfo.getSelectors());
+                    requestPathInfo.getSelectors(),true);
             servlets = locationUtil.getServlets(resourceResolver, resolutionCache.getScriptEngineExtensions());
         }
 

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
@@ -53,17 +53,21 @@ public abstract class AbstractResourceCollector {
     protected final String resourceSuperType;
 
     protected final String[] executionPaths;
+    
+    protected boolean useResourceCaching;
 
     protected AbstractResourceCollector(final String baseResourceType,
             final String resourceType,
             final String resourceSuperType,
             final String extension,
-            final String[] executionPaths) {
+            final String[] executionPaths,
+            final boolean useResourceCaching) {
         this.baseResourceType = baseResourceType;
         this.resourceType = resourceType;
         this.resourceSuperType = resourceSuperType;
         this.extension = extension;
         this.executionPaths = executionPaths;
+        this.useResourceCaching = useResourceCaching;
     }
 
     public final Collection<Resource> getServlets(final ResourceResolver resolver, final List<String> scriptExtensions) {
@@ -96,7 +100,8 @@ public abstract class AbstractResourceCollector {
         });
         
         
-        List<Resource> locations = LocationCollector.getLocations(resourceType, resourceSuperType, baseResourceType, resolver);
+        List<Resource> locations = LocationCollector.getLocations(resourceType, resourceSuperType, 
+        		baseResourceType, resolver, this.useResourceCaching);
         locations.forEach(locationRes -> getWeightedResources(resources, locationRes));
 
         List<Resource> result = new ArrayList<>(resources.size());

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
@@ -96,18 +96,8 @@ public abstract class AbstractResourceCollector {
         });
         
         
-        List<String> locations = LocationCollector.getLocations(resourceType, resourceSuperType, baseResourceType, resolver);
-        locations.forEach(location -> {
-            // get the location resource, use a synthetic resource if there
-            // is no real location. There may still be children at this
-            // location
-            final String path;
-            if ( location.endsWith("/") ) {
-                path = location.substring(0, location.length() - 1);
-            } else {
-                path = location;
-            }
-            final Resource locationRes = getResource(resolver, path);
+        List<Resource> locations = LocationCollector.getLocations(resourceType, resourceSuperType, baseResourceType, resolver);
+        locations.forEach(locationRes -> {
             getWeightedResources(resources, locationRes);
         });
 

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/AbstractResourceCollector.java
@@ -97,9 +97,7 @@ public abstract class AbstractResourceCollector {
         
         
         List<Resource> locations = LocationCollector.getLocations(resourceType, resourceSuperType, baseResourceType, resolver);
-        locations.forEach(locationRes -> {
-            getWeightedResources(resources, locationRes);
-        });
+        locations.forEach(locationRes -> getWeightedResources(resources, locationRes));
 
         List<Resource> result = new ArrayList<>(resources.size());
         result.addAll(resources);

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 
 class LocationCollector {
 
-	private static final String CACHE_KEY = LocationCollector.class.getName() + ".CacheKey";
+	protected static final String CACHE_KEY = LocationCollector.class.getName() + ".CacheKey";
 
     // The search path of the resource resolver
     private final String[] searchPath;

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -69,6 +69,7 @@ class LocationCollector {
     private final String baseResourceType;
     private final String resourceType;
     private final String resourceSuperType;
+    private final boolean useResourceCaching;
 
     /** Set of used resource types to detect a circular resource type hierarchy. */
     private final Set<String> usedResourceTypes = new HashSet<>();
@@ -78,13 +79,15 @@ class LocationCollector {
     private LocationCollector(@NotNull String resourceType, @NotNull String resourceSuperType, 
     		@NotNull String baseResourceType,
             @NotNull ResourceResolver resolver, 
-            @NotNull Map<String,Resource> cacheMap) {
+            @NotNull Map<String,Resource> cacheMap,
+            final boolean useResourceCaching) {
 
         this.resourceType = resourceType;
         this.resourceSuperType = resourceSuperType;
         this.baseResourceType = baseResourceType;
         this.resolver = resolver;
         this.cacheMap = cacheMap;
+        this.useResourceCaching = useResourceCaching;
 
         String[] tmpPath = resolver.getSearchPath();
         if (tmpPath.length == 0) {
@@ -220,7 +223,7 @@ class LocationCollector {
      * @return the resource for it or null
      */
     private @Nullable Resource resolveResource(@NotNull String path) {
-    	if (cacheMap.containsKey(path)) {
+    	if (useResourceCaching && cacheMap.containsKey(path)) {
     		return cacheMap.get(path);
     	} else {
     		Resource r = resolver.getResource(path);
@@ -245,11 +248,12 @@ class LocationCollector {
 	static @NotNull List<Resource> getLocations(@NotNull String resourceType, 
 			@NotNull String resourceSuperType, 
 			@NotNull String baseResourceType,
-			@NotNull ResourceResolver resolver) {
+			@NotNull ResourceResolver resolver,
+			boolean useResourceCaching) {
 		
 		final Map<String,Resource> cacheMap = getCacheMap(resolver);
 		final LocationCollector collector = new LocationCollector(resourceType, resourceSuperType, baseResourceType,
-				resolver, cacheMap);
+				resolver, cacheMap, useResourceCaching);
 		
 		// get the location resource, use a synthetic resource if there
 		// is no real location. There may still be children at this

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -243,7 +243,7 @@ class LocationCollector {
 		LocationCollector collector = new LocationCollector(resourceType, resourceSuperType, baseResourceType,
 				resolver, cacheMap);
 		List<Resource> result = new ArrayList<>();
-		collector.getResolvedLocations().forEach((location) -> {
+		collector.getResolvedLocations().forEach(location -> {
 			// get the location resource, use a synthetic resource if there
 			// is no real location. There may still be children at this
 			// location

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -234,12 +234,22 @@ class LocationCollector {
     
     // ---- static helpers ---
     
-	static @NotNull List<Resource> getLocations(String resourceType, String resourceSuperType, String baseResourceType,
-			ResourceResolver resolver) {
+    /**
+     * Return a list of resources, which represent potential matches for the given resourceType, resourceSuperType, 
+     * considering the constraints of the baseResourceType.
+     * @param resourceType 
+     * @param resourceSuperType
+     * @param baseResourceType
+     * @param resolver
+     * @return a list of non-null resources
+     */
+	static @NotNull List<Resource> getLocations(@NotNull String resourceType, 
+			@NotNull String resourceSuperType, 
+			@NotNull String baseResourceType,
+			@NotNull ResourceResolver resolver) {
 		
 		final Map<String,Resource> cacheMap = getCacheMap(resolver);
-		
-		LocationCollector collector = new LocationCollector(resourceType, resourceSuperType, baseResourceType,
+		final LocationCollector collector = new LocationCollector(resourceType, resourceSuperType, baseResourceType,
 				resolver, cacheMap);
 		
 		// get the location resource, use a synthetic resource if there

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollector.java
@@ -215,7 +215,7 @@ class LocationCollector {
      * @param path the path
      * @return the resource for it or null
      */
-    private @Nullable Resource resolveResource (@NotNull String path) {
+    private @Nullable Resource resolveResource(@NotNull String path) {
     	if (cacheMap.containsKey(path)) {
     		return cacheMap.get(path);
     	} else {

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/NamedScriptResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/NamedScriptResourceCollector.java
@@ -39,7 +39,8 @@ public class NamedScriptResourceCollector extends AbstractResourceCollector {
 
     public static NamedScriptResourceCollector create(final String name,
             final Resource resource,
-            final String[] executionPaths) {
+            final String[] executionPaths,
+            final boolean useResourceCaching) {
         final String resourceType;
         final String resourceSuperType;
         final String baseResourceType;
@@ -66,7 +67,8 @@ public class NamedScriptResourceCollector extends AbstractResourceCollector {
                 resourceSuperType,
                 scriptName,
                 extension,
-                executionPaths);
+                executionPaths,
+                useResourceCaching);
     }
 
     public NamedScriptResourceCollector(final String baseResourceType,
@@ -74,8 +76,9 @@ public class NamedScriptResourceCollector extends AbstractResourceCollector {
                               final String resourceSuperType,
                               final String scriptName,
                               final String extension,
-                              final String[] executionPaths) {
-        super(baseResourceType, resourceType, resourceSuperType, extension, executionPaths);
+                              final String[] executionPaths,
+                              final boolean useResourceCaching) {
+        super(baseResourceType, resourceType, resourceSuperType, extension, executionPaths, useResourceCaching);
         this.scriptName = scriptName;
         // create the hash code once
         final String key = baseResourceType + ':' + this.scriptName + ':' +

--- a/src/main/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollector.java
+++ b/src/main/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollector.java
@@ -86,20 +86,21 @@ public class ResourceCollector extends AbstractResourceCollector {
      */
     public static ResourceCollector create(
             final SlingHttpServletRequest request,
-            final String[] executionPaths, final String[] defaultExtensions) {
+            final String[] executionPaths, final String[] defaultExtensions, boolean UseResourceCaching) {
         final RequestPathInfo requestPathInfo = request.getRequestPathInfo();
         final boolean isDefaultExtension = ArrayUtils.contains(defaultExtensions, requestPathInfo.getExtension());
         return new ResourceCollector(request.getResource(), requestPathInfo.getExtension(), executionPaths, isDefaultExtension,
-                request.getMethod(), requestPathInfo.getSelectors());
+                request.getMethod(), requestPathInfo.getSelectors(), UseResourceCaching);
     }
 
     public static ResourceCollector create(final Resource resource,
             final String extension,
             final String[] executionPaths, final String[] defaultExtensions,
-            final String methodName, final String[] selectors
+            final String methodName, final String[] selectors, boolean useResourceCaching
             ) {
         boolean isDefaultExtension = ArrayUtils.contains(defaultExtensions, extension);
-        return new ResourceCollector(resource, extension, executionPaths, isDefaultExtension, methodName, selectors);
+        return new ResourceCollector(resource, extension, executionPaths, isDefaultExtension, 
+        		methodName, selectors, useResourceCaching);
     }
 
     /**
@@ -122,7 +123,7 @@ public class ResourceCollector extends AbstractResourceCollector {
     public ResourceCollector(final String methodName,
             final String baseResourceType, final Resource resource,
             final String[] executionPaths) {
-       this(methodName, baseResourceType, resource, null, executionPaths);
+       this(methodName, baseResourceType, resource, null, executionPaths,false);
     }
 
     /**
@@ -144,12 +145,13 @@ public class ResourceCollector extends AbstractResourceCollector {
     public ResourceCollector(final String methodName,
             final String baseResourceType, final Resource resource,
             final String extension,
-            final String[] executionPaths) {
+            final String[] executionPaths,
+            final boolean useResourceCaching) {
         super((baseResourceType != null
                 ? baseResourceType
                 : ServletResolverConstants.DEFAULT_RESOURCE_TYPE),
             resource.getResourceType(), resource.getResourceSuperType(),
-            extension, executionPaths);
+            extension, executionPaths, useResourceCaching);
         this.methodName = methodName;
         this.requestSelectors = new String[0];
         this.numRequestSelectors = 0;
@@ -185,11 +187,12 @@ public class ResourceCollector extends AbstractResourceCollector {
             final String[] executionPaths,
             final boolean isDefaultExtension,
             final String methodName,
-            final String[] selectors) {
+            final String[] selectors,
+            final boolean useResourceCaching) {
         super(ServletResolverConstants.DEFAULT_RESOURCE_TYPE,
                 resource.getResourceType(),
                 resource.getResourceSuperType(),
-                extension, executionPaths);
+                extension, executionPaths, useResourceCaching);
             this.methodName = methodName;
 
             this.suffExt = "." + extension;

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/IsSameResourceList.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/IsSameResourceList.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.servlets.resolver.internal.helper;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Custom matcher which compares the list of resources. For matching just the path
+ * of the resource is considered.
+ *
+ */
+public class IsSameResourceList extends TypeSafeMatcher<List<Resource>>{
+	
+	List<Resource> baseLine;
+	
+	private IsSameResourceList(List<Resource> baseline) {
+		this.baseLine = baseline;
+	}
+	
+	@Override
+	public boolean matchesSafely (List<Resource> item) {
+		
+		if (item.size() != baseLine.size()) {
+			return false;
+		}
+		for (int i=0; i < item.size(); i++) {
+			if (!sameResourcePath(item.get(i),baseLine.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("isSameListOfResources for");
+		
+	}
+	
+	
+	private boolean sameResourcePath (Resource a, Resource b) {
+		return a.getPath().equals(b.getPath());
+	}
+	
+	
+	public static Matcher<List<Resource>> isSameResourceList(List<Resource> baseline) {
+		return new IsSameResourceList(baseline);
+	}
+
+}

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/IsSameResourceList.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/IsSameResourceList.java
@@ -54,7 +54,7 @@ public class IsSameResourceList extends TypeSafeMatcher<List<Resource>>{
 	
 	@Override
 	public void describeTo(Description description) {
-		description.appendText("isSameListOfResources for");
+		description.appendText("isSameListOfResources for " + baseLine);
 		
 	}
 	

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
@@ -86,21 +86,6 @@ public class LocationCollectorTest {
         request.setResource(resource);
 		
 	}
-
-    List<Resource> getLocations(final String resourceType,
-            final String resourceSuperType) {
-        return getLocations(resourceType, resourceSuperType, DEFAULT_RESOURCE_TYPE);
-    }
-    
-    List<Resource> getLocations( final String resourceType,
-            final String resourceSuperType,
-            final String baseResourceType) {
-    	
-        return LocationCollector.getLocations(resourceType,
-                resourceSuperType,
-                baseResourceType,
-                resolver);
-    }
     
     @Test
     public void testSearchPathEmpty() {
@@ -134,6 +119,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath2Elements() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -175,6 +161,7 @@ public class LocationCollectorTest {
         request.setResource(r);
     }
 
+    @Test
     public void testSearchPathEmptyAbsoluteType() {
         // expect path gets { "/" }
         searchPathOptions.setSearchPaths(null);
@@ -194,6 +181,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath1ElementAbsoluteType() {
         String root0 = "/apps/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -216,6 +204,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath2ElementsAbsoluteType() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -240,6 +229,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPathEmptyWithSuper() {
         // expect path gets { "/" }
         searchPathOptions.setSearchPaths(null);
@@ -260,6 +250,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath1ElementWithSuper() {
         String root0 = "/apps/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -282,6 +273,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath2ElementsWithSuper() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -309,6 +301,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPathEmptyAbsoluteTypeWithSuper() {
         // expect path gets { "/" }
         searchPathOptions.setSearchPaths(null);
@@ -333,6 +326,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath1ElementAbsoluteTypeWithSuper() {
         String root0 = "/apps/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -359,6 +353,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testSearchPath2ElementsAbsoluteTypeWithSuper() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -389,6 +384,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testScriptNameWithoutResourceType() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -405,6 +401,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testScriptNameWithResourceType() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -422,6 +419,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testScriptNameWithResourceTypeAndSuperType() {
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -442,6 +440,7 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
+    @Test
     public void testCircularResourceTypeHierarchy() {
         final String root1 = "/libs/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -487,8 +486,13 @@ public class LocationCollectorTest {
         assertThat(loc,isSameResourceList(expected));
     }
     
-    
+    @Test
     public void testResolveDefaultResourceType() {
+    	
+    	searchPathOptions.setSearchPaths(new String[] {
+                "/apps/",
+                "/libs/"
+        });
     	
     	List<Resource> loc = getLocations(DEFAULT_RESOURCE_TYPE, resourceSuperType);
     	
@@ -500,7 +504,7 @@ public class LocationCollectorTest {
     	assertThat(loc,isSameResourceList(expected));
     }
  
-    
+    @Test
     public void testAbsoluteResourceSuperType() throws Exception {
         final String root = "/apps/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -533,7 +537,7 @@ public class LocationCollectorTest {
     	assertThat(loc,isSameResourceList(expected));
     }
     
-    
+    @Test
     public void testNoSuperType() throws Exception {
         final String root = "/apps/";
         searchPathOptions.setSearchPaths(new String[] {
@@ -559,10 +563,60 @@ public class LocationCollectorTest {
     	assertThat(loc,isSameResourceList(expected));
     }
     
+
+    @Test
+    public void checkThatTheCacheIsUsed() {
+
+    	// The basic test setup is copied from testSearchPath2ElementsWithSuper
+        String root0 = "/apps/";
+        String root1 = "/libs/";
+        searchPathOptions.setSearchPaths(new String[] {
+                root0,
+                root1
+        });
+
+        // set resource super type
+        resourceSuperType = "foo:superBar";
+        resourceSuperTypePath = ResourceUtil.resourceTypeToPath(resourceSuperType);
+        replaceResource(null, resourceSuperType);
+
+        final Resource r = request.getResource();
+        
+    	// Execute the same call twice and expect that on 2nd time the ResourceResolver
+    	// is never used, because all is taken from the cache
+        getLocations(r.getResourceType(),
+                r.getResourceSuperType());
+        
+        Mockito.clearInvocations(resolver);
+        
+        getLocations(r.getResourceType(),
+                r.getResourceSuperType());
+    	
+        Mockito.verify(resolver, Mockito.never()).getResource(Mockito.anyString());
+    }
+    
+    
+    // --- helper ---
+    
     private Resource r (String path) {
     	return new SyntheticResource(resolver, path, "resourcetype");
     }
     
+    
+    List<Resource> getLocations(final String resourceType,
+            final String resourceSuperType) {
+        return getLocations(resourceType, resourceSuperType, DEFAULT_RESOURCE_TYPE);
+    }
+    
+    List<Resource> getLocations( final String resourceType,
+            final String resourceSuperType,
+            final String baseResourceType) {
+    	
+        return LocationCollector.getLocations(resourceType,
+                resourceSuperType,
+                baseResourceType,
+                resolver);
+    }
     
     // Mimic the searchpath semantic of the ResourceResolverFactory
     public class SearchPathOptions {

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
@@ -23,6 +23,7 @@ import static org.apache.sling.servlets.resolver.internal.helper.HelperTestBase.
 import static org.apache.sling.servlets.resolver.internal.helper.HelperTestBase.getOrCreateParentResource;
 import static org.apache.sling.servlets.resolver.internal.helper.IsSameResourceList.isSameResourceList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -601,6 +602,31 @@ public class LocationCollectorTest {
                 r.getResourceSuperType());
     	
         Mockito.verify(resolver, Mockito.never()).getResource(Mockito.anyString());
+    }
+    
+    @Test
+    public void testWithCacheMapKeyAlreadyUsed() {
+    	// if the cacheKey in the ResourceResolverMap is already used, make sure that it's not overwritten
+    	// this is an adapted copy of the testSearchPath1Element testcase
+    	
+        String root0 = "/apps/";
+        searchPathOptions.setSearchPaths(new String[] {
+                root0
+        });
+
+        final Resource r = request.getResource();
+        final Object storedElement = "randomString";
+        r.getResourceResolver().getPropertyMap().put(LocationCollector.CACHE_KEY, storedElement);
+        List<Resource> loc = getLocations(r.getResourceType(),
+                r.getResourceSuperType());
+        
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + resourceTypePath), // /apps/foo/bar
+                r(root0 + DEFAULT_RESOURCE_TYPE)); // /apps/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
+    	
+        assertEquals(storedElement, r.getResourceResolver().getPropertyMap().get(LocationCollector.CACHE_KEY));
+    	
     }
     
     

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
@@ -19,28 +19,28 @@
 package org.apache.sling.servlets.resolver.internal.helper;
 
 import static org.apache.sling.api.servlets.ServletResolverConstants.DEFAULT_RESOURCE_TYPE;
+import static org.apache.sling.servlets.resolver.internal.helper.IsSameResourceList.isSameResourceList;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.resource.SyntheticResource;
 
 public class LocationCollectorTest extends HelperTestBase {
 
-    List<String> getLocations(final String resourceType,
+    List<Resource> getLocations(final String resourceType,
             final String resourceSuperType) {
         return getLocations(resourceType, resourceSuperType, DEFAULT_RESOURCE_TYPE);
     }
     
-    List<String> getLocations( final String resourceType,
+    List<Resource> getLocations( final String resourceType,
             final String resourceSuperType,
             final String baseResourceType) {
         return LocationCollector.getLocations(resourceType,
@@ -54,13 +54,13 @@ public class LocationCollectorTest extends HelperTestBase {
         resourceResolverOptions.setSearchPaths(null);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		"/" + resourceTypePath, // /foo/bar
-                "/" + DEFAULT_RESOURCE_TYPE); // /sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r("/" + resourceTypePath), // /foo/bar
+                r("/" + DEFAULT_RESOURCE_TYPE)); // /sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath1Element() {
@@ -70,13 +70,13 @@ public class LocationCollectorTest extends HelperTestBase {
         });
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		root0 + resourceTypePath, // /apps/foo/bar
-                root0 + DEFAULT_RESOURCE_TYPE); // /apps/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + resourceTypePath), // /apps/foo/bar
+                r(root0 + DEFAULT_RESOURCE_TYPE)); // /apps/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath2Elements() {
@@ -88,15 +88,15 @@ public class LocationCollectorTest extends HelperTestBase {
         });
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		root0 + resourceTypePath, // /apps/foo/bar
-                root1 + resourceTypePath, // /libs/foo/bar
-                root0 + DEFAULT_RESOURCE_TYPE, // /apps/sling/servlet/default
-                root1 + DEFAULT_RESOURCE_TYPE); // /libs/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + resourceTypePath), // /apps/foo/bar
+                r(root1 + resourceTypePath), // /libs/foo/bar
+                r(root0 + DEFAULT_RESOURCE_TYPE), // /apps/sling/servlet/default
+                r(root1 + DEFAULT_RESOURCE_TYPE)); // /libs/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     /**
@@ -130,13 +130,13 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                "/" + DEFAULT_RESOURCE_TYPE); // /sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+        		r("/" + DEFAULT_RESOURCE_TYPE)); // /sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath1ElementAbsoluteType() {
@@ -151,14 +151,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                root0 + DEFAULT_RESOURCE_TYPE); // /apps/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+                r(root0 + DEFAULT_RESOURCE_TYPE)); // /apps/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath2ElementsAbsoluteType() {
@@ -175,14 +175,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, null);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                root0 + DEFAULT_RESOURCE_TYPE, // /apps/sling/servlet/default
-                root1 + DEFAULT_RESOURCE_TYPE); // /libs/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+                r(root0 + DEFAULT_RESOURCE_TYPE), // /apps/sling/servlet/default
+                r(root1 + DEFAULT_RESOURCE_TYPE)); // /libs/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPathEmptyWithSuper() {
@@ -195,14 +195,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		"/" + resourceTypePath, // /foo/bar
-                "/" + resourceSuperTypePath, // /foo/superBar
-                "/" + DEFAULT_RESOURCE_TYPE); // /sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r("/" + resourceTypePath), // /foo/bar
+                r("/" + resourceSuperTypePath), // /foo/superBar
+                r("/" + DEFAULT_RESOURCE_TYPE)); // /sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath1ElementWithSuper() {
@@ -217,14 +217,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		root0 + resourceTypePath, // /apps/foo/bar
-                root0 + resourceSuperTypePath, // /apps/foo/superBar
-                root0 + DEFAULT_RESOURCE_TYPE); // /apps/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + resourceTypePath), // /apps/foo/bar
+                r(root0 + resourceSuperTypePath), // /apps/foo/superBar
+                r(root0 + DEFAULT_RESOURCE_TYPE)); // /apps/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath2ElementsWithSuper() {
@@ -241,17 +241,17 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(null, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		root0 + resourceTypePath, // /apps/foo/bar
-                root1 + resourceTypePath, // /libs/foo/bar
-                root0 + resourceSuperTypePath, // /apps/foo/superBar
-                root1 + resourceSuperTypePath, // /libs/foo/superBar
-                root0 + DEFAULT_RESOURCE_TYPE, // /apps/sling/servlet/default
-                root1 + DEFAULT_RESOURCE_TYPE); // /libs/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + resourceTypePath), // /apps/foo/bar
+                r(root1 + resourceTypePath), // /libs/foo/bar
+                r(root0 + resourceSuperTypePath), // /apps/foo/superBar
+                r(root1 + resourceSuperTypePath), // /libs/foo/superBar
+                r(root0 + DEFAULT_RESOURCE_TYPE), // /apps/sling/servlet/default
+                r(root1 + DEFAULT_RESOURCE_TYPE)); // /libs/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPathEmptyAbsoluteTypeWithSuper() {
@@ -268,14 +268,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                "/" + resourceSuperTypePath, // /foo/superBar
-                "/" + DEFAULT_RESOURCE_TYPE); // /sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+                r("/" + resourceSuperTypePath), // /foo/superBar
+                r("/" + DEFAULT_RESOURCE_TYPE)); // /sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath1ElementAbsoluteTypeWithSuper() {
@@ -294,14 +294,14 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                root0 + resourceSuperTypePath, // /apps/foo/superBar
-                root0 + DEFAULT_RESOURCE_TYPE); // /apps/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+                r(root0 + resourceSuperTypePath), // /apps/foo/superBar
+                r(root0 + DEFAULT_RESOURCE_TYPE)); // /apps/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testSearchPath2ElementsAbsoluteTypeWithSuper() {
@@ -322,16 +322,16 @@ public class LocationCollectorTest extends HelperTestBase {
         replaceResource(resourceType, resourceSuperType);
 
         final Resource r = request.getResource();
-        List<String> loc = getLocations(r.getResourceType(),
+        List<Resource> loc = getLocations(r.getResourceType(),
                 r.getResourceSuperType());
         
-        List<String> expected = Arrays.asList(
-        		resourceTypePath, // /foo/bar
-                root0 + resourceSuperTypePath, // /apps/foo/superBar
-                root1 + resourceSuperTypePath, // /libs/foo/superBar
-                root0 + DEFAULT_RESOURCE_TYPE, // /apps/sling/servlet/default
-                root1 + DEFAULT_RESOURCE_TYPE); // /libs/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(resourceTypePath), // /foo/bar
+                r(root0 + resourceSuperTypePath), // /apps/foo/superBar
+                r(root1 + resourceSuperTypePath), // /libs/foo/superBar
+                r(root0 + DEFAULT_RESOURCE_TYPE), // /apps/sling/servlet/default
+                r(root1 + DEFAULT_RESOURCE_TYPE)); // /libs/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testScriptNameWithoutResourceType() {
@@ -341,11 +341,13 @@ public class LocationCollectorTest extends HelperTestBase {
                 root0,
                 root1
         });
-        List<String> loc = getLocations("",
+        List<Resource> loc = getLocations("",
                 null,"");
         
-        List<String> expected = Arrays.asList("/apps/","/libs/");
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r("/apps"),
+        		r("/libs"));
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testScriptNameWithResourceType() {
@@ -355,14 +357,14 @@ public class LocationCollectorTest extends HelperTestBase {
                 root0,
                 root1
         });
-        List<String> loc = getLocations("a/b", null);
+        List<Resource> loc = getLocations("a/b", null);
         
-        List<String> expected = Arrays.asList(
-        		root0 + "a/b",
-                root1 + "a/b",
-                root0 + DEFAULT_RESOURCE_TYPE,
-                root1 + DEFAULT_RESOURCE_TYPE);
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + "a/b"),
+                r(root1 + "a/b"),
+                r(root0 + DEFAULT_RESOURCE_TYPE),
+                r(root1 + DEFAULT_RESOURCE_TYPE));
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testScriptNameWithResourceTypeAndSuperType() {
@@ -373,16 +375,16 @@ public class LocationCollectorTest extends HelperTestBase {
                 root1
         });
         
-        List<String> loc = getLocations("a/b", "c/d");
+        List<Resource> loc = getLocations("a/b", "c/d");
 
-        List<String> expected = Arrays.asList(
-        		root0 + "a/b",
-                root1 + "a/b",
-                root0 + "c/d",
-                root1 + "c/d",
-                root0 + DEFAULT_RESOURCE_TYPE,
-                root1 + DEFAULT_RESOURCE_TYPE);
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root0 + "a/b"),
+                r(root1 + "a/b"),
+                r(root0 + "c/d"),
+                r(root1 + "c/d"),
+                r(root0 + DEFAULT_RESOURCE_TYPE),
+                r(root1 + DEFAULT_RESOURCE_TYPE));
+        assertThat(loc,isSameResourceList(expected));
     }
     
     public void testCircularResourceTypeHierarchy() {
@@ -420,28 +422,27 @@ public class LocationCollectorTest extends HelperTestBase {
             fail("Did not expect a persistence exception: " + e.getMessage());
         }
         
-        List<String> loc = getLocations(resourceType, resourceSuperType);
+        List<Resource> loc = getLocations(resourceType, resourceSuperType);
         
-        List<String> expected = Arrays.asList(
-        		root1 + resourceType, // /libs/foo/bar
-                root1 + resourceSuperType, // /libs/foo/check1
-                root1 + resourceSuperType2, // /libs/foo/check2
-                root1 + DEFAULT_RESOURCE_TYPE); // /libs/sling/servlet/default
-        assertThat(loc,is(expected));
+        List<Resource> expected = Arrays.asList(
+        		r(root1 + resourceType), // /libs/foo/bar
+                r(root1 + resourceSuperType), // /libs/foo/check1
+                r(root1 + resourceSuperType2), // /libs/foo/check2
+                r(root1 + DEFAULT_RESOURCE_TYPE)); // /libs/sling/servlet/default
+        assertThat(loc,isSameResourceList(expected));
     }
     
     
     public void testResolveDefaultResourceType() {
     	
-    	List<String> loc = getLocations(DEFAULT_RESOURCE_TYPE, resourceSuperType);
+    	List<Resource> loc = getLocations(DEFAULT_RESOURCE_TYPE, resourceSuperType);
     	
-    	List<String> expected = Arrays.asList(
-    			"/apps/sling/servlet/default",
-    			"/libs/sling/servlet/default",
-    			"/apps/sling/servlet/default",
-    			"/libs/sling/servlet/default"
-    			);
-    	assertThat(loc,is(expected));
+    	List<Resource> expected = Arrays.asList(
+    			r("/apps/sling/servlet/default"),
+    			r("/libs/sling/servlet/default"),
+    			r("/apps/sling/servlet/default"),
+    			r("/libs/sling/servlet/default"));
+    	assertThat(loc,isSameResourceList(expected));
     }
  
     
@@ -467,14 +468,14 @@ public class LocationCollectorTest extends HelperTestBase {
 				ResourceUtil.getName(resourceSuperTypePath), null);
         
         
-    	List<String> loc = getLocations(resourceType, resourceSuperType);
+    	List<Resource> loc = getLocations(resourceType, resourceSuperType);
     	
-    	List<String> expected = Arrays.asList(
-    			resourceTypePath,      			// /apps/a/b
-    			resourceSuperTypePath, 			// /apps/c/d
-    			root + DEFAULT_RESOURCE_TYPE 	// /apps/sling/servlet/default
+    	List<Resource> expected = Arrays.asList(
+    			r(resourceTypePath),      			// /apps/a/b
+    			r(resourceSuperTypePath), 			// /apps/c/d
+    			r(root + DEFAULT_RESOURCE_TYPE) 	// /apps/sling/servlet/default
     			);
-    	assertThat(loc,is(expected));
+    	assertThat(loc,isSameResourceList(expected));
     }
     
     
@@ -494,13 +495,17 @@ public class LocationCollectorTest extends HelperTestBase {
 				ResourceUtil.getName(resourceTypePath), resourceTypeProps);
         
         
-    	List<String> loc = getLocations(resourceType, resourceSuperType);
+    	List<Resource> loc = getLocations(resourceType, resourceSuperType);
     	
-    	List<String> expected = Arrays.asList(
-    			resourceTypePath,      			// /apps/a/b
-    			root + DEFAULT_RESOURCE_TYPE 	// /apps/sling/servlet/default
+    	List<Resource> expected = Arrays.asList(
+    			r(resourceTypePath),      			// /apps/a/b
+    			r(root + DEFAULT_RESOURCE_TYPE) 	// /apps/sling/servlet/default
     			);
-    	assertThat(loc,is(expected));
+    	assertThat(loc,isSameResourceList(expected));
+    }
+    
+    private Resource r (String path) {
+    	return new SyntheticResource(resourceResolver, path, "resourcetype");
     }
     
 }

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
@@ -23,7 +23,6 @@ import static org.apache.sling.servlets.resolver.internal.helper.HelperTestBase.
 import static org.apache.sling.servlets.resolver.internal.helper.HelperTestBase.getOrCreateParentResource;
 import static org.apache.sling.servlets.resolver.internal.helper.IsSameResourceList.isSameResourceList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -441,7 +440,7 @@ public class LocationCollectorTest {
     }
     
     @Test
-    public void testCircularResourceTypeHierarchy() {
+    public void testCircularResourceTypeHierarchy() throws PersistenceException {
         final String root1 = "/libs/";
         searchPathOptions.setSearchPaths(new String[] {
                 root1
@@ -456,27 +455,18 @@ public class LocationCollectorTest {
         Map<String, Object> resource2Props = new HashMap<>();
         resource2Props.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, resourceType);
         resource2Props.put("sling:resourceSuperType", resourceSuperType2);
-        try {
-            resolver.create(getOrCreateParentResource(resolver, resource2Path),
+        resolver.create(getOrCreateParentResource(resolver, resource2Path),
                     ResourceUtil.getName(resource2Path),
                     resource2Props);
-        } catch (PersistenceException e) {
-            fail("Did not expect a persistence exception: " + e.getMessage());
-        }
 
         String resource3Path = root1 + resourceSuperType2;
         Map<String, Object> resource3Props = new HashMap<>();
         resource3Props.put(ResourceResolver.PROPERTY_RESOURCE_TYPE, resourceType);
-        resource3Props.put("sling:resourceSuperType", resourceType);
-        try {
-        	resolver.create(getOrCreateParentResource(resolver, resource3Path),
-                    ResourceUtil.getName(resource3Path),
-                    resource3Props);
-        } catch (PersistenceException e) {
-            fail("Did not expect a persistence exception: " + e.getMessage());
-        }
-        
-        List<Resource> loc = getLocations(resourceType, resourceSuperType);
+		resource3Props.put("sling:resourceSuperType", resourceType);
+		resolver.create(getOrCreateParentResource(resolver, resource3Path), ResourceUtil.getName(resource3Path),
+				resource3Props);
+
+		List<Resource> loc = getLocations(resourceType, resourceSuperType);
         
         List<Resource> expected = Arrays.asList(
         		r(root1 + resourceType), // /libs/foo/bar

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/LocationCollectorTest.java
@@ -40,10 +40,23 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mockito;
 
-
+@RunWith(Parameterized.class)
 public class LocationCollectorTest {
+	
+	// Run the test both with and without resource caching enabled
+	@Parameters
+	public static Iterable<Object> data() {
+		return Arrays.asList(true, false);
+	}
+	
+	@Parameter
+	public boolean useResourceCaching;
 	
 	@Rule
 	public final SlingContext context = new SlingContext();
@@ -557,6 +570,11 @@ public class LocationCollectorTest {
     @Test
     public void checkThatTheCacheIsUsed() {
 
+    	// skip if the test runs without caching
+    	if (!useResourceCaching) {
+    		return;
+    	}
+    	
     	// The basic test setup is copied from testSearchPath2ElementsWithSuper
         String root0 = "/apps/";
         String root1 = "/libs/";
@@ -605,7 +623,7 @@ public class LocationCollectorTest {
         return LocationCollector.getLocations(resourceType,
                 resourceSuperType,
                 baseResourceType,
-                resolver);
+                resolver, useResourceCaching);
     }
     
     // Mimic the searchpath semantic of the ResourceResolverFactory

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollectorTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ResourceCollectorTest.java
@@ -389,7 +389,7 @@ public class ResourceCollectorTest extends HelperTestBase {
             pathMap.put(name, path);
         }
 
-        ResourceCollector lu = ResourceCollector.create(request, null, new String[] {"html"});
+        ResourceCollector lu = ResourceCollector.create(request, null, new String[] {"html"}, true);
         Collection<Resource> res;
         if (scriptEngineExtensions != null) {
             res = lu.getServlets(request.getResourceResolver(), scriptEngineExtensions);

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelection2Test.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelection2Test.java
@@ -171,7 +171,7 @@ public class ScriptSelection2Test {
                               List<String> scriptEngineFactoriesExtensions, String... expectedScripts) {
         SlingHttpServletRequest request = prepareRequest(method, contentResource, selectors, extension);
         final ResourceCollector collector =
-                ResourceCollector.create(request, context.resourceResolver().getSearchPath(), new String[]{"html"});
+                ResourceCollector.create(request, context.resourceResolver().getSearchPath(), new String[]{"html"}, true);
         final Collection<Resource> s = collector.getServlets(request.getResourceResolver(), scriptEngineFactoriesExtensions);
         if (expectedScripts == null || expectedScripts.length == 0) {
             assertFalse("No script must be found", s.iterator().hasNext());

--- a/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
+++ b/src/test/java/org/apache/sling/servlets/resolver/internal/helper/ScriptSelectionTest.java
@@ -67,7 +67,7 @@ public class ScriptSelectionTest extends HelperTestBase {
 
         // Create mock request and get scripts from ResourceCollector
         final MockSlingHttpServletRequest req = makeRequest(method, selectors, extension);
-        final ResourceCollector u = ResourceCollector.create(req, null, new String[] {"html"});
+        final ResourceCollector u = ResourceCollector.create(req, null, new String[] {"html"}, true);
         final Collection<Resource> s = u.getServlets(req.getResourceResolver(), Collections.emptyList());
 
         if(expectedScript == null) {


### PR DESCRIPTION
The ``LocationCollector`` returns now a list of ``Resources`` instead of Strings. Internally it uses a Map (stored within ``ResourceResolver.getPropertyMap()``, thus this map shares the lifecycle of the resourceResolver) to cache already resolved resources.

The benefit of this cache for a single servlet resolution is likely quite small; but I expect that the benefit in real-life applications is much higher, especially when multiple servlets of the same type are resolved in the context of a resourceresolver. I plan to do some tests next week and share numbers.