### PR TITLE
chore(deps): upgrade sling-bundle-parent to version 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Bumps the Maven parent POM version for the Apache Sling bundle to pick up the latest shared build configuration and dependency management.

- Updated `sling-bundle-parent` version from `62` to `66` in `pom.xml`

Co-authored-by: Maia <maia@noreply>