### PR TITLE
docs: update AGENTS.md and README.md for resolver cache concurrency hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Project overview
 
-Apache Sling Servlets Resolver is an OSGi bundle that implements Sling servlet and script resolution services. It provides `ServletResolver`, the deprecated `SlingScriptResolver` bridge (`SlingScriptResolverImpl`), and Sling error handling integration, resolving requests by traversing resource-type hierarchies with selector/extension/method matching. It also tracks servlets registered as OSGi services, mounts them as virtual resources, handles bundled scripts via the `sling.servlet` capability, maintains resolver caches (with JMX exposure), and provides a Felix Web Console plugin for diagnostics. Requires Java 17. Built with Maven and packaged as an OSGi bundle via bnd.
+Apache Sling Servlets Resolver is an OSGi bundle that implements Sling servlet and script resolution services. It provides `ServletResolver`, the deprecated `SlingScriptResolver` bridge (`SlingScriptResolverImpl`), and Sling error handling integration, resolving requests by traversing resource-type hierarchies with selector/extension/method matching. It also tracks servlets registered as OSGi services, mounts them as virtual resources, handles bundled scripts via the `sling.servlet` capability, maintains resolver caches (with JMX exposure), and provides a Felix Web Console plugin for diagnostics. Recent resolver-cache hardening adds generation-aware cache writes to prevent stale servlet entries during concurrent cache flushes. Requires Java 17. Built with Maven and packaged as an OSGi bundle via bnd.
 
 # Core commands
 
@@ -9,6 +9,7 @@ Apache Sling Servlets Resolver is an OSGi bundle that implements Sling servlet a
 - **Unit tests only:** `mvn test`
 - **Integration tests only (requires built jar):** `mvn verify -Dsurefire.skip=true`
 - **Single unit test class:** `mvn test -Dtest=ResourceCollectorTest`
+- **Race-condition regression unit test:** `mvn test -Dtest=ResolutionCacheRaceConditionTest`
 - **Single integration test class:** `mvn verify -Dit.test=ServletSelectionIT`
 - **Single resource-hiding integration test class:** `mvn verify -Dit.test=BasicResourceHidingIT`
 - **SpotBugs static analysis:** `mvn spotbugs:check`
@@ -54,6 +55,7 @@ src/
         WebConsolePlugin.java               Felix Web Console diagnostic plugin
   test/java/org/apache/sling/servlets/resolver/
     internal/                               Unit tests (JUnit 4 + Mockito + Sling mocks)
+      ResolutionCacheRaceConditionTest.java Regression test for cache flush/put race handling
     internal/resourcehiding/                Unit tests for hiding predicate behavior
     it/                                     Pax Exam integration tests
     it/resourcehiding/                      Integration tests for hidden servlet fallback behavior
@@ -71,6 +73,7 @@ target/                                     Build output — do not edit
 - **Formatting:** 4-space indentation, no tabs. Follow existing code style; Spotless may run via the parent build, so keep formatting consistent with existing files.
 - **Package visibility:** Keep implementation classes in `*.internal.*`; only stable extension points belong in exported API packages (for example `org.apache.sling.servlets.resolver.api`).
 - **Both servlet APIs:** The codebase supports both `javax.servlet` (Servlet 4) and `jakarta.servlet` (Servlet 6.1). When adding servlet-related code check both paths.
+- **Resolution cache concurrency:** When adding resolver caching logic, capture `ResolutionCache` generation before resolution and pass it to cache writes; cache flushes and writes are coordinated via read/write locking to prevent stale re-population.
 - **No public API changes without versioning:** OSGi semantic versioning is enforced via the `baseline` plugin. Changing exported package APIs requires a version bump aligned with OSGi rules.
 
 # Git workflow
@@ -86,7 +89,7 @@ target/                                     Build output — do not edit
 - **Unit test framework:** JUnit 4 (`junit:junit`), Mockito 5, Sling OSGi Mock (`org.apache.sling.testing.osgi-mock`), Sling Mock (`org.apache.sling.testing.sling-mock`).
 - **Integration test framework:** Pax Exam 4 with a forked OSGi container (Felix Framework). Tests suffixed `IT` run via `maven-failsafe-plugin`.
 - **Test placement:** Unit tests in `src/test/java/.../internal/` (including `internal/resourcehiding/`); integration tests in `src/test/java/.../it/` (including `it/resourcehiding/`).
-- **Coverage focus:** Prioritize resolution logic (`ResourceCollector`, `LocationCollector`, `SlingServletResolver`), bundled-script tracking/health checks, and resource-hiding behavior via `IgnoredServletResourcePredicate`.
+- **Coverage focus:** Prioritize resolution logic (`ResourceCollector`, `LocationCollector`, `SlingServletResolver`), cache invalidation/concurrency behavior (`ResolutionCache`, resolver cache-generation interactions), bundled-script tracking/health checks, and resource-hiding behavior via `IgnoredServletResourcePredicate`.
 - **Running a single unit test:** `mvn test -Dtest=ClassName`
 - **Running a single IT:** `mvn verify -Dit.test=ClassName`
 - Integration tests spin up a real OSGi framework; they are slow (~1–2 min) and require the bundle jar to be built first.
@@ -99,10 +102,10 @@ target/                                     Build output — do not edit
 - **OSGi baseline check:** Adding or changing exported types without bumping the package version causes a build failure. Run `mvn verify` to catch this early.
 - **Pax Exam memory:** The forked OSGi container starts with `-Xmx512M` by default. Override with `-Dpax.vm.options` if tests OOM.
 - **`ResolutionCache`** is a required OSGi service dependency of `SlingServletResolver`. In tests that mock the resolver, this must be provided or the component will not activate.
+- **Resolver cache race safety:** A `flushCache()` can occur while request resolution is in progress. Resolver changes that touch cache writes must preserve generation-based stale-write rejection (capture generation before lookup/resolve, and only cache if generation is unchanged at put time).
 
 # Security
 
 <!-- sling-security-default:start -->
 The threat model for this project is https://github.com/apache/sling/blob/master/docs/threat-model.md .
 <!-- sling-security-default:end -->
-

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the [servlets](https://sling.apache.org/documentation/the-sling-engine/servl
 - Mounts OSGi servlet services into the resource tree through dedicated resource providers
 - Tracks bundled scripts contributed through OSGi capabilities (`sling.servlet`)
 - Maintains servlet/script resolution caches with JMX inspection and cache management support
+- Hardens cache concurrency with generation-aware cache writes to prevent stale servlet re-population after cache flushes
 - Includes resolver diagnostics through a Felix Web Console plugin
 - Supports optional servlet/script hiding via `IgnoredServletResourcePredicate`
 - Provides a configurable bundled-script health check (`BundledScriptTrackerHC`)
@@ -36,6 +37,7 @@ This module requires **Java 17** and uses Maven.
 - Run verification without integration tests: `mvn verify -DskipITs`
 - Run SpotBugs check: `mvn spotbugs:check`
 - Run a single unit test class: `mvn test -Dtest=ResourceCollectorTest`
+- Run cache race-condition regression test: `mvn test -Dtest=ResolutionCacheRaceConditionTest`
 - Run a single integration test class: `mvn verify -Dit.test=ServletSelectionIT`
 
 ## Project structure
@@ -58,7 +60,7 @@ src/main/java/org/apache/sling/servlets/resolver/
     console/     (Web Console diagnostics)
 
 src/test/java/org/apache/sling/servlets/resolver/
-  internal/      (unit tests)
+  internal/      (unit tests, including ResolutionCacheRaceConditionTest)
   internal/resourcehiding/  (unit tests for hiding predicate behavior)
   it/            (Pax Exam integration tests)
   it/resourcehiding/  (integration tests for hidden servlet fallback behavior)


### PR DESCRIPTION
Updates project documentation to reflect the resolver-cache race-condition hardening work.

- Add note to project overview describing generation-aware cache writes that prevent stale servlet entries during concurrent cache flushes
- Document `ResolutionCacheRaceConditionTest` as a regression test in command examples, file tree, and test placement guidance
- Add coding guideline for capturing `ResolutionCache` generation before resolution and passing it to cache writes
- Expand coverage-focus guidance to include cache invalidation/concurrency behavior (`ResolutionCache`, cache-generation interactions)
- Add pitfall note about resolver cache race safety and stale-write rejection requirements
- Update README feature list and build commands to mention cache concurrency hardening and the new regression test
- Clarify `src/test` structure comment to reference `ResolutionCacheRaceConditionTest`
- Remove trailing blank line at end of AGENTS.md

Co-authored-by: Maia <maia@noreply>